### PR TITLE
Repository name and ubuntu-device-flash fixes

### DIFF
--- a/.tarmac.sh
+++ b/.tarmac.sh
@@ -7,8 +7,8 @@ export GOPATH=$(mktemp -d)
 trap 'rm -rf "$GOPATH"' EXIT
 
 # this is a hack, but not sure tarmac is golang friendly
-mkdir -p $GOPATH/src/launchpad.net/goget-ubuntu-touch
-cp -a . $GOPATH/src/launchpad.net/goget-ubuntu-touch
-cd $GOPATH/src/launchpad.net/goget-ubuntu-touch
+mkdir -p $GOPATH/src/github.com/ubports/goget-ubuntu-touch
+cp -a . $GOPATH/src/github.com/ubports/goget-ubuntu-touch
+cd $GOPATH/src/github.com/ubports/goget-ubuntu-touch
 
 ./run-checks

--- a/bootimg/example/abootimg-extract/main.go
+++ b/bootimg/example/abootimg-extract/main.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"os"
 
-	"launchpad.net/goget-ubuntu-touch/bootimg"
+	"github.com/ubports/goget-ubuntu-touch/bootimg"
 )
 
 func checkError(err error) {

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: goget-ubuntu-touch
-Source: https://launchpad.net/goget-ubuntu-touch
+Source: https://github.com/ubports/goget-ubuntu-touch
 
 Files: *
 Copyright: Copyright (C) 2013 Canonical, Ltd.

--- a/debian/golang-goget-ubuntu-touch-bootimg-dev.install
+++ b/debian/golang-goget-ubuntu-touch-bootimg-dev.install
@@ -1,1 +1,1 @@
-usr/share/gocode/src/launchpad.net/goget-ubuntu-touch/bootimg
+usr/share/gocode/src/github.com/ubports/goget-ubuntu-touch/bootimg

--- a/debian/golang-goget-ubuntu-touch-devices-dev.install
+++ b/debian/golang-goget-ubuntu-touch-devices-dev.install
@@ -1,1 +1,1 @@
-usr/share/gocode/src/launchpad.net/goget-ubuntu-touch/devices
+usr/share/gocode/src/github.com/ubports/goget-ubuntu-touch/devices

--- a/debian/golang-goget-ubuntu-touch-ubuntuimage-dev.install
+++ b/debian/golang-goget-ubuntu-touch-ubuntuimage-dev.install
@@ -1,1 +1,1 @@
-usr/share/gocode/src/launchpad.net/goget-ubuntu-touch/ubuntuimage
+usr/share/gocode/src/github.com/ubports/goget-ubuntu-touch/ubuntuimage

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 # -*- makefile -*-
 
 export DH_OPTIONS
-export DH_GOPKG := launchpad.net/goget-ubuntu-touch
+export DH_GOPKG := github.com/ubports/goget-ubuntu-touch
 
 %:
 	dh $@ --buildsystem=golang --with=golang --fail-missing --with bash-completion
@@ -10,8 +10,8 @@ export DH_GOPKG := launchpad.net/goget-ubuntu-touch
 override_dh_auto_install:
 	dh_auto_install -O--buildsystem=golang
 	rm -rf ${CURDIR}/debian/tmp/usr/bin/abootimg-extract
-	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/launchpad.net/goget-ubuntu-touch/ubuntu-emulator
-	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/launchpad.net/goget-ubuntu-touch/ubuntu-device-flash
-	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/launchpad.net/goget-ubuntu-touch/ubuntu-device-do
-	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/launchpad.net/goget-ubuntu-touch/diskimage
-	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/launchpad.net/goget-ubuntu-touch/sysutils
+	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/github.com/ubports/goget-ubuntu-touch/ubuntu-emulator
+	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/github.com/ubports/goget-ubuntu-touch/ubuntu-device-flash
+	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/github.com/ubports/goget-ubuntu-touch/ubuntu-device-do
+	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/github.com/ubports/goget-ubuntu-touch/diskimage
+	rm -rf ${CURDIR}/debian/tmp/usr/share/gocode/src/github.com/ubports/goget-ubuntu-touch/sysutils

--- a/diskimage/bootloader.go
+++ b/diskimage/bootloader.go
@@ -27,7 +27,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"launchpad.net/goget-ubuntu-touch/sysutils"
+	"github.com/ubports/goget-ubuntu-touch/sysutils"
 )
 
 func setupBootAssetFiles(bootMount, bootPath, oemRootPath string, files []BootAssetFiles) error {

--- a/diskimage/bootloader_test.go
+++ b/diskimage/bootloader_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	. "launchpad.net/gocheck"
-	"launchpad.net/goget-ubuntu-touch/sysutils"
+	"github.com/ubports/goget-ubuntu-touch/sysutils"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/diskimage/common.go
+++ b/diskimage/common.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"syscall"
 
-	"launchpad.net/goget-ubuntu-touch/sysutils"
+	"github.com/ubports/goget-ubuntu-touch/sysutils"
 )
 
 // This program is free software: you can redistribute it and/or modify it

--- a/diskimage/core_grub.go
+++ b/diskimage/core_grub.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"launchpad.net/goget-ubuntu-touch/sysutils"
+	"github.com/ubports/goget-ubuntu-touch/sysutils"
 )
 
 // This program is free software: you can redistribute it and/or modify it

--- a/diskimage/core_uboot.go
+++ b/diskimage/core_uboot.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"launchpad.net/goget-ubuntu-touch/sysutils"
+	"github.com/ubports/goget-ubuntu-touch/sysutils"
 )
 
 // This program is free software: you can redistribute it and/or modify it

--- a/diskimage/image.go
+++ b/diskimage/image.go
@@ -29,7 +29,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"launchpad.net/goget-ubuntu-touch/sysutils"
+	"github.com/ubports/goget-ubuntu-touch/sysutils"
 )
 
 type DiskImage struct {

--- a/run-checks
+++ b/run-checks
@@ -31,7 +31,7 @@ godeps -u dependencies.tsv
 
 
 echo Building
-go build -v launchpad.net/goget-ubuntu-touch/...
+go build -v github.com/ubports/goget-ubuntu-touch/...
 
 
 # tests

--- a/ubuntu-device-do/factory_reset.go
+++ b/ubuntu-device-do/factory_reset.go
@@ -24,8 +24,8 @@ import (
 
 	"log"
 
-	"launchpad.net/goget-ubuntu-touch/devices"
-	"launchpad.net/goget-ubuntu-touch/ubuntuimage"
+	"github.com/ubports/goget-ubuntu-touch/devices"
+	"github.com/ubports/goget-ubuntu-touch/ubuntuimage"
 )
 
 type FactoryResetCmd struct {

--- a/ubuntu-device-flash/common.go
+++ b/ubuntu-device-flash/common.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"syscall"
 
-	"launchpad.net/goget-ubuntu-touch/sysutils"
-	"launchpad.net/goget-ubuntu-touch/ubuntuimage"
+	"github.com/ubports/goget-ubuntu-touch/sysutils"
+	"github.com/ubports/goget-ubuntu-touch/ubuntuimage"
 )
 
 func getImage(deviceChannel ubuntuimage.DeviceChannel) (image ubuntuimage.Image, err error) {

--- a/ubuntu-device-flash/main.go
+++ b/ubuntu-device-flash/main.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"os"
 
-	"launchpad.net/goget-ubuntu-touch/ubuntuimage"
+	"github.com/ubports/goget-ubuntu-touch/ubuntuimage"
 )
 
 import flags "github.com/jessevdk/go-flags"
@@ -61,7 +61,7 @@ func execute(args []string) {
 		return
 	}
 
-	if _, err := parser.ParseArgs(args); err != nil {
+	if _, err := parser.ParseArgs(args[1:]); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/ubuntu-device-flash/query.go
+++ b/ubuntu-device-flash/query.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 
-	"launchpad.net/goget-ubuntu-touch/ubuntuimage"
+	"github.com/ubports/goget-ubuntu-touch/ubuntuimage"
 )
 
 func init() {

--- a/ubuntu-device-flash/snappy.go
+++ b/ubuntu-device-flash/snappy.go
@@ -11,8 +11,8 @@ package main
 import (
 	"fmt"
 
-	"launchpad.net/goget-ubuntu-touch/diskimage"
-	"launchpad.net/goget-ubuntu-touch/ubuntuimage"
+	"github.com/ubports/goget-ubuntu-touch/diskimage"
+	"github.com/ubports/goget-ubuntu-touch/ubuntuimage"
 )
 
 type imageFlavor string

--- a/ubuntu-device-flash/touch.go
+++ b/ubuntu-device-flash/touch.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/goget-ubuntu-touch/devices"
-	"launchpad.net/goget-ubuntu-touch/ubuntuimage"
+	"github.com/ubports/goget-ubuntu-touch/devices"
+	"github.com/ubports/goget-ubuntu-touch/ubuntuimage"
 )
 
 func init() {

--- a/ubuntu-emulator/common.go
+++ b/ubuntu-emulator/common.go
@@ -27,7 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"launchpad.net/goget-ubuntu-touch/bootimg"
+	"github.com/ubports/goget-ubuntu-touch/bootimg"
 )
 
 func getDeviceTar(files []string) (string, error) {

--- a/ubuntu-emulator/create.go
+++ b/ubuntu-emulator/create.go
@@ -30,9 +30,9 @@ import (
 	"syscall"
 	"text/template"
 
-	"launchpad.net/goget-ubuntu-touch/diskimage"
-	"launchpad.net/goget-ubuntu-touch/sysutils"
-	"launchpad.net/goget-ubuntu-touch/ubuntuimage"
+	"github.com/ubports/goget-ubuntu-touch/diskimage"
+	"github.com/ubports/goget-ubuntu-touch/sysutils"
+	"github.com/ubports/goget-ubuntu-touch/ubuntuimage"
 )
 
 type CreateCmd struct {

--- a/ubuntu-emulator/snapshot.go
+++ b/ubuntu-emulator/snapshot.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"launchpad.net/goget-ubuntu-touch/diskimage"
+	"github.com/ubports/goget-ubuntu-touch/diskimage"
 )
 
 type SnapshotCmd struct {

--- a/ubuntu-emulator/stamp.go
+++ b/ubuntu-emulator/stamp.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"launchpad.net/goget-ubuntu-touch/ubuntuimage"
+	"github.com/ubports/goget-ubuntu-touch/ubuntuimage"
 )
 
 func writeDeviceStamp(dataDir, device string) (err error) {


### PR DESCRIPTION
This is the same as #2

## Repository name fixes
Changed all launchpad repository references to this github repository. Note: I'm not really sure about [this line](https://github.com/ubports/goget-ubuntu-touch/commit/3e1c03d98c09862775db87dfe637ef23771d9a0c#diff-d837a1c17de0268bcea321239ddbed47R16) and in general all changes that are not in .go files.

## ubuntu-device-flash fix
I don't know why it stopped working, maybe some third party package api change, but every command call resulted in `Unknown command ```ubuntu-device-flash'. Please specify one command of: core, personal, query or touch```. This was fixed [here](https://github.com/ubports/goget-ubuntu-touch/commit/9b0bae2773aa829ac9e096a88ccc7f075565875f#diff-57b600b4c74be95da1ef2d082c2d4421R64).

Note: I see, that there are some files for go package dependencies, but I'm not familiar with dependencies tools and I used only classic ```go get```/```go build``` tools. 